### PR TITLE
feat : Profile 컴포넌트 구현

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -27,7 +27,7 @@ const ProfileContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 250px;
-  height: 301px;
+  height: 300px;
   justify-content: space-between;
   text-decoration: none;
   color: inherit;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -7,16 +7,15 @@ type ProfileProps = {
 };
 
 const Profile = ({ name, imgUrl, linkUrl }: ProfileProps) => {
-  const handleClick = () => {
-    window.open(linkUrl, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <ProfileContainer>
-      <ProfileImage src={imgUrl} alt="Profile" onClick={handleClick} />
-
+      <ProfileLink href={linkUrl} target="_blank" rel="noopener noreferrer">
+        <ProfileImage src={imgUrl} alt="Profile" />
+      </ProfileLink>
       <ProfileNameContainer>
-        <ProfileName onClick={handleClick}>{name}</ProfileName>
+        <ProfileName href={linkUrl} target="_blank" rel="noopener noreferrer">
+          {name}
+        </ProfileName>
       </ProfileNameContainer>
     </ProfileContainer>
   );
@@ -32,6 +31,15 @@ const ProfileContainer = styled.div`
   justify-content: space-between;
   text-decoration: none;
   color: inherit;
+`;
+
+const ProfileLink = styled.a`
+  display: inline-block;
+  width: 250px;
+  height: 250px;
+  border-radius: 50%;
+  overflow: hidden;
+  cursor: pointer;
 `;
 
 const ProfileImage = styled.img`
@@ -52,6 +60,8 @@ const ProfileNameContainer = styled.div`
   ${({ theme }) => theme.fonts.subHeading};
 `;
 
-const ProfileName = styled.span`
+const ProfileName = styled.a`
+  text-decoration: none;
+  color: inherit;
   cursor: pointer;
 `;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -34,7 +34,6 @@ const ProfileContainer = styled.div`
 `;
 
 const ProfileLink = styled.a`
-  display: inline-block;
   width: 250px;
   height: 250px;
   border-radius: 50%;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -8,37 +8,32 @@ type ProfileProps = {
 
 const Profile = ({ name, imgUrl, linkUrl }: ProfileProps) => {
   return (
-    <ProfileContainer>
-      <ProfileLink href={linkUrl} target="_blank" rel="noopener noreferrer">
-        <ProfileImage src={imgUrl} alt="Profile" />
-      </ProfileLink>
-      <ProfileNameContainer>
-        <ProfileName href={linkUrl} target="_blank" rel="noopener noreferrer">
-          {name}
-        </ProfileName>
-      </ProfileNameContainer>
+    <ProfileContainer href={linkUrl} target="_blank" rel="noopener noreferrer">
+      <ProfileImage src={imgUrl} alt="Profile" />
+      <ProfileName>{name}</ProfileName>
     </ProfileContainer>
   );
 };
 
 export default Profile;
 
-const ProfileContainer = styled.div`
+const ProfileContainer = styled.a`
   display: flex;
   flex-direction: column;
-  width: 250px;
-  height: 300px;
+  width: 262px;
+  height: 312px;
   justify-content: space-between;
   text-decoration: none;
   color: inherit;
-`;
-
-const ProfileLink = styled.a`
-  width: 250px;
-  height: 250px;
-  border-radius: 50%;
-  overflow: hidden;
+  box-sizing: border-box;
+  padding: 6px;
   cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray1};
+  }
 `;
 
 const ProfileImage = styled.img`
@@ -48,17 +43,10 @@ const ProfileImage = styled.img`
   border-radius: 50%;
 `;
 
-const ProfileNameContainer = styled.div`
-  display: inline-block;
+const ProfileName = styled.p`
   display: flex;
   align-items: center;
   justify-content: center;
-
-  ${({ theme }) => theme.fonts.subHeading};
-`;
-
-const ProfileName = styled.a`
   text-decoration: none;
   color: inherit;
-  cursor: pointer;
 `;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -47,8 +47,6 @@ const ProfileImage = styled.img`
   height: 250px;
   object-fit: cover;
   border-radius: 50%;
-  clip-path: circle(50% at 50% 50%);
-  cursor: pointer;
 `;
 
 const ProfileNameContainer = styled.div`

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+
+type ProfileProps = {
+  name: string;
+  imgUrl: string;
+  linkUrl: string;
+};
+
+const Profile = ({ name, imgUrl, linkUrl }: ProfileProps) => {
+  const handleClick = () => {
+    window.open(linkUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <ProfileContainer>
+      <ProfileImage src={imgUrl} alt="Profile" onClick={handleClick} />
+
+      <ProfileNameContainer>
+        <ProfileName onClick={handleClick}>{name}</ProfileName>
+      </ProfileNameContainer>
+    </ProfileContainer>
+  );
+};
+
+export default Profile;
+
+const ProfileContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+  height: 301px;
+  justify-content: space-between;
+  text-decoration: none;
+  color: inherit;
+`;
+
+const ProfileImage = styled.img`
+  width: 250px;
+  height: 250px;
+  object-fit: cover;
+  border-radius: 50%;
+  clip-path: circle(50% at 50% 50%);
+  cursor: pointer;
+`;
+
+const ProfileNameContainer = styled.div`
+  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ theme }) => theme.fonts.subHeading};
+`;
+
+const ProfileName = styled.span`
+  cursor: pointer;
+`;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,25 +1,30 @@
 export const PROFILE = [
   {
+    id: 'hanheel',
     name: 'Blue',
     imgUrl: 'https://avatars.githubusercontent.com/u/168459001?v=4',
     linkUrl: 'https://github.com/hanheel/',
   },
   {
+    id: 'sanghee01',
     name: 'Sangchu',
     imgUrl: 'https://avatars.githubusercontent.com/u/80993302?v=4',
     linkUrl: 'https://github.com/sanghee01/',
   },
   {
+    id: 'dev-dino22',
     name: 'Camel',
     imgUrl: 'https://avatars.githubusercontent.com/u/141295691?v=4',
     linkUrl: 'https://github.com/dev-dino22/',
   },
   {
+    id: 'Daeun-100',
     name: 'Diane',
     imgUrl: 'https://avatars.githubusercontent.com/u/141714293?v=4',
     linkUrl: 'https://github.com/Daeun-100/',
   },
   {
+    id: 'JeLee-river',
     name: 'Jenna',
     imgUrl: 'https://avatars.githubusercontent.com/u/106021313?v=4',
     linkUrl: 'https://github.com/JeLee-river/',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,11 @@
-export const PROFILE = [
+export type Profile = {
+  id: string;
+  name: string;
+  imgUrl: string;
+  linkUrl: string;
+};
+
+export const PROFILES: Profile[] = [
   {
     id: 'hanheel',
     name: 'Blue',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,27 @@
+export const PROFILE = [
+  {
+    name: 'Blue',
+    imgUrl: 'https://avatars.githubusercontent.com/u/168459001?v=4',
+    linkUrl: 'https://github.com/hanheel/',
+  },
+  {
+    name: 'Sangchu',
+    imgUrl: 'https://avatars.githubusercontent.com/u/80993302?v=4',
+    linkUrl: 'https://github.com/sanghee01/',
+  },
+  {
+    name: 'Camel',
+    imgUrl: 'https://avatars.githubusercontent.com/u/141295691?v=4',
+    linkUrl: 'https://github.com/dev-dino22/',
+  },
+  {
+    name: 'Diane',
+    imgUrl: 'https://avatars.githubusercontent.com/u/141714293?v=4',
+    linkUrl: 'https://github.com/Daeun-100/',
+  },
+  {
+    name: 'Jenna',
+    imgUrl: 'https://avatars.githubusercontent.com/u/106021313?v=4',
+    linkUrl: 'https://github.com/JeLee-river/',
+  },
+];

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,11 +1,11 @@
 import Profile from '../components/Profile';
-import { PROFILE } from '../consts';
+import { PROFILES } from '../consts';
 
 const Test = () => {
   return (
     <div>
       <h1>Test Component</h1>
-      {PROFILE.map((profile) => (
+      {PROFILES.map((profile) => (
         <Profile
           key={profile.id}
           name={profile.name}

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -5,9 +5,9 @@ const Test = () => {
   return (
     <div>
       <h1>Test Component</h1>
-      {PROFILE.map((profile, index) => (
+      {PROFILE.map((profile) => (
         <Profile
-          key={index}
+          key={profile.id}
           name={profile.name}
           imgUrl={profile.imgUrl}
           linkUrl={profile.linkUrl}

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,32 +1,5 @@
 import Profile from '../components/Profile';
-
-const PROFILE = [
-  {
-    name: 'Blue',
-    imgUrl: 'https://avatars.githubusercontent.com/u/168459001?v=4',
-    linkUrl: 'https://github.com/hanheel/',
-  },
-  {
-    name: 'Sangchu',
-    imgUrl: 'https://avatars.githubusercontent.com/u/80993302?v=4',
-    linkUrl: 'https://github.com/sanghee01/',
-  },
-  {
-    name: 'Camel',
-    imgUrl: 'https://avatars.githubusercontent.com/u/141295691?v=4',
-    linkUrl: 'https://github.com/dev-dino22/',
-  },
-  {
-    name: 'Diane',
-    imgUrl: 'https://avatars.githubusercontent.com/u/141714293?v=4',
-    linkUrl: 'https://github.com/Daeun-100/',
-  },
-  {
-    name: 'Jenna',
-    imgUrl: 'https://avatars.githubusercontent.com/u/106021313?v=4',
-    linkUrl: 'https://github.com/JeLee-river/',
-  },
-];
+import { PROFILE } from '../consts';
 
 const Test = () => {
   return (

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,8 +1,45 @@
+import Profile from '../components/Profile';
+
+const PROFILE = [
+  {
+    name: 'Blue',
+    imgUrl: 'https://avatars.githubusercontent.com/u/168459001?v=4',
+    linkUrl: 'https://github.com/hanheel/',
+  },
+  {
+    name: 'Sangchu',
+    imgUrl: 'https://avatars.githubusercontent.com/u/80993302?v=4',
+    linkUrl: 'https://github.com/sanghee01/',
+  },
+  {
+    name: 'Camel',
+    imgUrl: 'https://avatars.githubusercontent.com/u/141295691?v=4',
+    linkUrl: 'https://github.com/dev-dino22/',
+  },
+  {
+    name: 'Diane',
+    imgUrl: 'https://avatars.githubusercontent.com/u/141714293?v=4',
+    linkUrl: 'https://github.com/Daeun-100/',
+  },
+  {
+    name: 'Jenna',
+    imgUrl: 'https://avatars.githubusercontent.com/u/106021313?v=4',
+    linkUrl: 'https://github.com/JeLee-river/',
+  },
+];
+
 const Test = () => {
   return (
     <div>
       <h1>Test Component</h1>
-      <p>This is a test component to verify the setup.</p>
+      {PROFILE.map((profile, index) => (
+        <Profile
+          key={index}
+          name={profile.name}
+          imgUrl={profile.imgUrl}
+          linkUrl={profile.linkUrl}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## 📝작업 내용

- Profile 컴포넌트를 구현했습니다.
- 이미지와 이름을 클릭하면 깃헙페이지로 넘어갑니다. 

## 세부사항

처음에는 a 태그를 사용하여 페이지가 넘어가는 기능을 구현했습니다. 그러나 이 방법 사용시 border-radius로 만든 원모양 바깥의 box 영역도 클릭되는 문제가 발생하였습니다. 

그래서  `window.open(linkUrl, '_blank', 'noopener,noreferrer');` 이벤트를 사용하여 클릭 이벤트 발생시 페이지가 넘어가도록 변경하였습니다. 


### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/23a0ac59-a422-4bb2-a397-c647ef6c4f6b)



## 💬리뷰 요구사항


